### PR TITLE
chore: use issue types in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: 'Bug report 🪲'
 description: 'Report that something does not work as expected.'
-labels: ['bug :beetle:']
+type: 'Bug'
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: 'Feature request 💡'
 description: 'Suggest an idea for this project.'
-labels: ['enhancement :bulb:']
+type: 'Feature'
 
 body:
   - type: textarea


### PR DESCRIPTION
### Summary of Changes

Use the new issue types instead of labels for newly created issues.
